### PR TITLE
Re-export jsonx and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![GitHub Actions](https://github.com/FartLabs/htx/actions/workflows/check.yaml/badge.svg)](https://github.com/FartLabs/htx/actions/workflows/check.yaml)
 
-Render HTML components with JSX.
+Render HTML components with JSX powered by Deno and
+[**@fartlabs/jsonx**](https://jsr.io/@fartlabs/jsonx).
 
 ## API documentation
 
@@ -12,7 +13,7 @@ Generated API documentation is available at <https://jsr.io/@fartlabs/htx>.
 
 ### Deno
 
-Let's learn how to get started with rtx by creating a simple router in Deno.
+Let's learn how to get started with htx by creating a simple router in Deno.
 
 1\. [Install Deno](https://docs.deno.com/runtime/manual).
 
@@ -22,10 +23,10 @@ Let's learn how to get started with rtx by creating a simple router in Deno.
 deno init
 ```
 
-3\. Add `@fartlabs/jsonx` and `@fartlabs/htx` as project dependencies.
+3\. Add `@fartlabs/htx` as a project dependency.
 
 ```sh
-deno add @fartlabs/jsonx @fartlabs/htx
+deno add @fartlabs/htx
 ```
 
 4\. Add the following values to your `deno.json(c)` file.
@@ -34,7 +35,7 @@ deno add @fartlabs/jsonx @fartlabs/htx
 {
   "compilerOptions": {
     "jsx": "react-jsx",
-    "jsxImportSource": "@fartlabs/jsonx"
+    "jsxImportSource": "@fartlabs/htx"
   }
 }
 ```

--- a/area.tsx
+++ b/area.tsx
@@ -10,6 +10,5 @@ export type { AreaElementProps };
 export function AREA(
   props: AreaElementProps & { children?: string[] } = {},
 ): string {
-  const { children, ...rest } = props;
-  return render(rest);
+  return render(props);
 }

--- a/base.tsx
+++ b/base.tsx
@@ -10,6 +10,5 @@ export type { BaseElementProps };
 export function BASE(
   props: BaseElementProps & { children?: string[] } = {},
 ): string {
-  const { children, ...rest } = props;
-  return render(rest);
+  return render(props);
 }

--- a/br.tsx
+++ b/br.tsx
@@ -10,6 +10,5 @@ export type { BrElementProps };
 export function BR(
   props: BrElementProps & { children?: string[] } = {},
 ): string {
-  const { children, ...rest } = props;
-  return render(rest);
+  return render(props);
 }

--- a/cli/codegen.ts
+++ b/cli/codegen.ts
@@ -45,11 +45,9 @@ if (import.meta.main) {
         initializer: "{}",
       }],
       returnType: "string",
-      statements: [
+      statements: descriptor.isVoid ? ["return render(props);"] : [
         "const { children, ...rest } = props;",
-        descriptor.isVoid
-          ? "return render(rest);"
-          : "return render(rest, ...(children ?? []));",
+        "return render(rest, ...(children ?? []));",
       ],
       docs: toDocs({
         description:
@@ -67,6 +65,7 @@ if (import.meta.main) {
     undefined,
     { overwrite: true },
   );
+  modFile.addStatements(`export * from "./special/mod.ts";`);
   for (const descriptor of descriptors) {
     modFile.addStatements(`export * from "./${descriptor.tag}.tsx";`);
   }
@@ -78,6 +77,7 @@ if (import.meta.main) {
   const denoConfig = JSON.parse(await Deno.readTextFile("./deno.json"));
   denoConfig.exports = {
     ".": "./mod.ts",
+    "./jsx-runtime": "./jsx-runtime.ts",
     ...Object.fromEntries(descriptors.map((descriptor) => [
       `./${descriptor.tag}`,
       `./${descriptor.tag}.tsx`,

--- a/col.tsx
+++ b/col.tsx
@@ -10,6 +10,5 @@ export type { ColElementProps };
 export function COL(
   props: ColElementProps & { children?: string[] } = {},
 ): string {
-  const { children, ...rest } = props;
-  return render(rest);
+  return render(props);
 }

--- a/deno.json
+++ b/deno.json
@@ -16,7 +16,7 @@
   },
   "exports": {
     ".": "./mod.ts",
-    "./special": "./special/mod.ts",
+    "./jsx-runtime": "./jsx-runtime.ts",
     "./a": "./a.tsx",
     "./abbr": "./abbr.tsx",
     "./acronym": "./acronym.tsx",

--- a/embed.tsx
+++ b/embed.tsx
@@ -10,6 +10,5 @@ export type { EmbedElementProps };
 export function EMBED(
   props: EmbedElementProps & { children?: string[] } = {},
 ): string {
-  const { children, ...rest } = props;
-  return render(rest);
+  return render(props);
 }

--- a/hr.tsx
+++ b/hr.tsx
@@ -10,6 +10,5 @@ export type { HrElementProps };
 export function HR(
   props: HrElementProps & { children?: string[] } = {},
 ): string {
-  const { children, ...rest } = props;
-  return render(rest);
+  return render(props);
 }

--- a/img.tsx
+++ b/img.tsx
@@ -10,6 +10,5 @@ export type { ImgElementProps };
 export function IMG(
   props: ImgElementProps & { children?: string[] } = {},
 ): string {
-  const { children, ...rest } = props;
-  return render(rest);
+  return render(props);
 }

--- a/input.tsx
+++ b/input.tsx
@@ -10,6 +10,5 @@ export type { InputElementProps };
 export function INPUT(
   props: InputElementProps & { children?: string[] } = {},
 ): string {
-  const { children, ...rest } = props;
-  return render(rest);
+  return render(props);
 }

--- a/jsx-runtime.ts
+++ b/jsx-runtime.ts
@@ -1,0 +1,1 @@
+export * from "@fartlabs/jsonx/jsx-runtime";

--- a/link.tsx
+++ b/link.tsx
@@ -10,6 +10,5 @@ export type { LinkElementProps };
 export function LINK(
   props: LinkElementProps & { children?: string[] } = {},
 ): string {
-  const { children, ...rest } = props;
-  return render(rest);
+  return render(props);
 }

--- a/meta.tsx
+++ b/meta.tsx
@@ -10,6 +10,5 @@ export type { MetaElementProps };
 export function META(
   props: MetaElementProps & { children?: string[] } = {},
 ): string {
-  const { children, ...rest } = props;
-  return render(rest);
+  return render(props);
 }

--- a/mod.ts
+++ b/mod.ts
@@ -1,3 +1,4 @@
+export * from "./special/mod.ts";
 export * from "./a.tsx";
 export * from "./abbr.tsx";
 export * from "./acronym.tsx";

--- a/param.tsx
+++ b/param.tsx
@@ -11,6 +11,5 @@ export type { ParamElementProps };
 export function PARAM(
   props: ParamElementProps & { children?: string[] } = {},
 ): string {
-  const { children, ...rest } = props;
-  return render(rest);
+  return render(props);
 }

--- a/source.tsx
+++ b/source.tsx
@@ -10,6 +10,5 @@ export type { SourceElementProps };
 export function SOURCE(
   props: SourceElementProps & { children?: string[] } = {},
 ): string {
-  const { children, ...rest } = props;
-  return render(rest);
+  return render(props);
 }

--- a/track.tsx
+++ b/track.tsx
@@ -10,6 +10,5 @@ export type { TrackElementProps };
 export function TRACK(
   props: TrackElementProps & { children?: string[] } = {},
 ): string {
-  const { children, ...rest } = props;
-  return render(rest);
+  return render(props);
 }

--- a/wbr.tsx
+++ b/wbr.tsx
@@ -10,6 +10,5 @@ export type { WbrElementProps };
 export function WBR(
   props: WbrElementProps & { children?: string[] } = {},
 ): string {
-  const { children, ...rest } = props;
-  return render(rest);
+  return render(props);
 }


### PR DESCRIPTION
### Changes

- Update README.md to reflect the sole dependency on `@fartlabs/htx` (we no longer require a separate dependency on `@fartlabs/jsonx` for the jsx runtime).
- Add re-export to `@fartlabs/jsonx/jsx-runtime` in `deno.json` file.
- Add re-export `./special/mod.ts` to `./mod.ts` file.
- Fix lint error.